### PR TITLE
fix (cors) : Configure CORS with origin and credentials

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,7 +23,10 @@ app.use(express.json({limit: '5mb'}));
 app.use(express.urlencoded({extended: true}));
 app.use(cookieParser());
 app.use(process.env.STATICS_URL, express.static(path.join(__dirname, 'public')));
-app.use(cors());
+app.use(cors({
+    origin: process.env.CORS_ORIGIN,
+    credentials: true
+  }));
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerConfig));
 
 process.env.TZ = "Asia/Tehran";


### PR DESCRIPTION
Updated CORS middleware to use a specific origin from the CORS_ORIGIN environment variable and enabled credentials support. This enhances security by restricting allowed origins and supporting credentialed requests.